### PR TITLE
Enable strain calculation for multiple timepoints

### DIFF
--- a/test1.R
+++ b/test1.R
@@ -9,70 +9,62 @@ library(akima)      # For interpolation
 library(pracma)     # For gradient calculation
 library(ggplot2)
 
-# ---- Load or Simulate Data ----
-# Simulate some example data (you can replace this with your own CSV or dataframe)
-set.seed(123)
-n_points <- 100
-time_points <- c(0, 1)
+# ---- Load Data ----
+# The example script originally generated synthetic data for two time points.
+# To work with real tracking data containing many time points we read the CSV
+# file provided with this repository.  It must contain four columns:
+# `cell_id`, `frame`, `x` and `y`.
+tracks <- read.csv("sample1.csv")
 
-# Generate synthetic point positions
-tracks <- data.frame(
-  id = rep(1:n_points, each = 2),
-  time = rep(time_points, times = n_points),
-  x = rep(runif(n_points, 0, 10), each = 2),
-  y = rep(runif(n_points, 0, 10), each = 2)
-)
+# Rename columns to generic names used later in the script
+colnames(tracks) <- c("id", "time", "x", "y")
 
-# Add small synthetic displacement for time = 1
-tracks <- tracks %>%
-  group_by(id) %>%
-  mutate(
-    x = ifelse(time == 1, x + 0.1 * x + rnorm(1, 0, 0.02), x),
-    y = ifelse(time == 1, y + 0.05 * y + rnorm(1, 0, 0.02), y)
-  ) %>%
-  ungroup()
+# Ensure ordering by time
+tracks <- tracks %>% arrange(time, id)
 
 # ---- Select Reference and Deformed Time Points ----
+# The reference frame is typically the first (time = 0).  Strain fields will be
+# computed for all later frames listed in `def_times`.
 ref_time <- 0
-def_time <- 1
+def_times <- sort(unique(tracks$time))
+def_times <- def_times[def_times > ref_time]
 
-ref <- tracks %>% filter(time == ref_time)
-def <- tracks %>% filter(time == def_time)
+# ---- Strain Calculation Helper ----
+compute_strain <- function(data, ref_time, def_time, grid_n = 100) {
+  ref <- data %>% filter(time == ref_time)
+  def <- data %>% filter(time == def_time)
 
-# Merge positions by ID
-merged <- inner_join(ref, def, by = "id", suffix = c("_ref", "_def"))
+  merged <- inner_join(ref, def, by = "id", suffix = c("_ref", "_def")) %>%
+    mutate(
+      u = x_def - x_ref,
+      v = y_def - y_ref
+    )
 
-# Calculate displacements
-merged <- merged %>%
-  mutate(
-    u = x_def - x_ref,
-    v = y_def - y_ref
+  x_seq <- seq(min(merged$x_ref), max(merged$x_ref), length.out = grid_n)
+  y_seq <- seq(min(merged$y_ref), max(merged$y_ref), length.out = grid_n)
+
+  u_interp <- with(merged, interp(x_ref, y_ref, u, xo = x_seq, yo = y_seq, linear = TRUE))
+  v_interp <- with(merged, interp(x_ref, y_ref, v, xo = x_seq, yo = y_seq, linear = TRUE))
+
+  dx <- diff(u_interp$x[1:2])
+  dy <- diff(u_interp$y[1:2])
+
+  grad_u <- gradient(u_interp$z)
+  grad_v <- gradient(v_interp$z)
+
+  du_dx <- grad_u$X / dx
+  du_dy <- grad_u$Y / dy
+  dv_dx <- grad_v$X / dx
+  dv_dy <- grad_v$Y / dy
+
+  list(
+    x = u_interp$x,
+    y = u_interp$y,
+    epsilon_xx = du_dx,
+    epsilon_yy = dv_dy,
+    epsilon_xy = 0.5 * (du_dy + dv_dx)
   )
-
-# ---- Interpolate to Grid ----
-x_seq <- seq(min(merged$x_ref), max(merged$x_ref), length.out = 100)
-y_seq <- seq(min(merged$y_ref), max(merged$y_ref), length.out = 100)
-
-u_interp <- with(merged, interp(x_ref, y_ref, u, xo = x_seq, yo = y_seq, linear = TRUE))
-v_interp <- with(merged, interp(x_ref, y_ref, v, xo = x_seq, yo = y_seq, linear = TRUE))
-
-# ---- Compute Gradients and Strains ----
-dx <- diff(u_interp$x[1:2])
-dy <- diff(u_interp$y[1:2])
-
-# Compute gradients assuming unit spacing
-grad_u <- gradient(u_interp$z)
-grad_v <- gradient(v_interp$z)
-
-# Scale by actual grid spacing
-du_dx <- grad_u$X / dx
-du_dy <- grad_u$Y / dy
-dv_dx <- grad_v$X / dx
-dv_dy <- grad_v$Y / dy
-
-epsilon_xx <- du_dx
-epsilon_yy <- dv_dy
-epsilon_xy <- 0.5 * (du_dy + dv_dx)
+}
 
 # ---- Visualization Helper ----
 plot_strain_field <- function(x, y, field, title = "Strain", palette = terrain.colors) {
@@ -84,7 +76,14 @@ plot_strain_field <- function(x, y, field, title = "Strain", palette = terrain.c
   )
 }
 
-# ---- Plot Strain Fields ----
-plot_strain_field(u_interp$x, u_interp$y, epsilon_xx, title = "Strain εxx")
-plot_strain_field(u_interp$x, u_interp$y, epsilon_yy, title = "Strain εyy")
-plot_strain_field(u_interp$x, u_interp$y, epsilon_xy, title = "Strain εxy")
+# ---- Loop Over Time Points ----
+for (t in def_times) {
+  strain <- compute_strain(tracks, ref_time, t)
+
+  plot_strain_field(strain$x, strain$y, strain$epsilon_xx,
+                    title = paste0("Strain εxx (t=", t, ")"))
+  plot_strain_field(strain$x, strain$y, strain$epsilon_yy,
+                    title = paste0("Strain εyy (t=", t, ")"))
+  plot_strain_field(strain$x, strain$y, strain$epsilon_xy,
+                    title = paste0("Strain εxy (t=", t, ")"))
+}


### PR DESCRIPTION
## Summary
- load sample tracking data instead of synthesising
- compute strain fields for every timepoint relative to the reference
- loop over all frames and plot results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880e881a8cc8332b739e1271cca6d5f